### PR TITLE
feat: add configurable logging

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+
+const levels = ['debug', 'info', 'warn', 'error'];
+
+function createLogger(options = {}) {
+  const levelName = (options.level || process.env.LOG_LEVEL || 'info').toLowerCase();
+  const levelIndex = levels.indexOf(levelName);
+  const logFile = options.logFile || process.env.LOG_FILE;
+
+  function log(lvl, ...args) {
+    if (levels.indexOf(lvl) < levelIndex) return;
+    const timestamp = new Date().toISOString();
+    const message = `[${timestamp}] ${lvl.toUpperCase()}: ${args.join(' ')}`;
+    const consoleMethod = lvl === 'debug' ? 'log' : lvl;
+    console[consoleMethod](message);
+    if (logFile) {
+      fs.appendFile(logFile, message + '\n', err => {
+        if (err) console.error(`[LOGGER ERROR] ${err.message}`);
+      });
+    }
+  }
+
+  return {
+    debug: (...a) => log('debug', ...a),
+    info: (...a) => log('info', ...a),
+    warn: (...a) => log('warn', ...a),
+    error: (...a) => log('error', ...a)
+  };
+}
+
+module.exports = { createLogger };


### PR DESCRIPTION
## Summary
- add reusable logger with configurable level and optional file output
- instrument server with detailed connection and request logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba9886da3c83219e4147d2a1e6c42f