### PR TITLE
feat: add configurable logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <div id="inputRow">
     <input id="text" autocomplete="off" placeholder="Type a message" />
     <button id="send">Send</button>
+    <a id="downloadLogs" href="/logs">Download Logs</a>
   </div>
   <script>
     const statusEl = document.getElementById('status');

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+
+const levels = ['debug', 'info', 'warn', 'error'];
+
+function createLogger(options = {}) {
+  const levelName = (options.level || process.env.LOG_LEVEL || 'info').toLowerCase();
+  const levelIndex = levels.indexOf(levelName);
+  const logFile = options.logFile || process.env.LOG_FILE;
+
+  function log(lvl, ...args) {
+    if (levels.indexOf(lvl) < levelIndex) return;
+    const timestamp = new Date().toISOString();
+    const message = `[${timestamp}] ${lvl.toUpperCase()}: ${args.join(' ')}`;
+    const consoleMethod = lvl === 'debug' ? 'log' : lvl;
+    console[consoleMethod](message);
+    if (logFile) {
+      fs.appendFile(logFile, message + '\n', err => {
+        if (err) console.error(`[LOGGER ERROR] ${err.message}`);
+      });
+    }
+  }
+
+  return {
+    debug: (...a) => log('debug', ...a),
+    info: (...a) => log('info', ...a),
+    warn: (...a) => log('warn', ...a),
+    error: (...a) => log('error', ...a)
+  };
+}
+
+module.exports = { createLogger };

--- a/server.js
+++ b/server.js
@@ -1,9 +1,11 @@
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const { createLogger } = require('./logger');
 
 function startServer(port = process.env.PORT || 8080) {
   const clients = new Set();
+  const logger = createLogger();
 
   const server = http.createServer((req, res) => {
     if (req.url === '/events') {
@@ -14,26 +16,50 @@ function startServer(port = process.env.PORT || 8080) {
       });
       res.write(':connected\n\n');
       clients.add(res);
+      logger.info(`Client connected: ${req.socket.remoteAddress}`);
       const keepAlive = setInterval(() => {
         res.write(':keepalive\n\n');
       }, 30000);
       req.on('close', () => {
         clearInterval(keepAlive);
         clients.delete(res);
+        logger.info(`Client disconnected: ${req.socket.remoteAddress}`);
       });
     } else if (req.method === 'POST' && req.url === '/message') {
       let body = '';
       req.on('data', chunk => (body += chunk));
       req.on('end', () => {
+        logger.info(`Broadcasting message to ${clients.size} client(s): ${body}`);
         for (const client of clients) {
           client.write(`data: ${body}\n\n`);
         }
         res.writeHead(204);
         res.end();
       });
+    } else if (req.method === 'GET' && req.url === '/logs') {
+      const logFile = process.env.LOG_FILE;
+      if (!logFile) {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      fs.readFile(logFile, (err, data) => {
+        if (err) {
+          logger.error(`Error reading log file: ${err.message}`);
+          res.writeHead(500);
+          res.end('Server error');
+          return;
+        }
+        res.writeHead(200, {
+          'Content-Type': 'text/plain',
+          'Content-Disposition': `attachment; filename="${path.basename(logFile)}"`
+        });
+        res.end(data);
+      });
     } else if (req.method === 'GET' && (req.url === '/' || req.url === '/index.html')) {
       fs.readFile(path.join(__dirname, 'index.html'), (err, data) => {
         if (err) {
+          logger.error(`Error reading index.html: ${err.message}`);
           res.writeHead(500);
           res.end('Server error');
           return;
@@ -42,13 +68,14 @@ function startServer(port = process.env.PORT || 8080) {
         res.end(data);
       });
     } else {
+      logger.warn(`Unhandled request: ${req.method} ${req.url}`);
       res.writeHead(404);
       res.end();
     }
   });
 
   server.listen(port, () => {
-    console.log(`Server running on port ${port}`);
+    logger.info(`Server running on port ${port}`);
   });
 
   return server;


### PR DESCRIPTION
## Summary
- add reusable logger with configurable level and optional file output
- instrument server with detailed connection and request logging
- expose `/logs` endpoint and UI link for downloading the log file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba9886da3c83219e4147d2a1e6c42f