### PR TITLE
fix: enable log downloads

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,8 @@ const { createLogger } = require('./logger');
 
 function startServer(port = process.env.PORT || 8080) {
   const clients = new Set();
-  const logger = createLogger();
+  const logFile = process.env.LOG_FILE || path.join(__dirname, 'server.log');
+  const logger = createLogger({ logFile });
 
   const server = http.createServer((req, res) => {
     if (req.url === '/events') {
@@ -45,12 +46,6 @@ function startServer(port = process.env.PORT || 8080) {
         res.end();
       });
     } else if (req.method === 'GET' && req.url === '/logs') {
-      const logFile = process.env.LOG_FILE;
-      if (!logFile) {
-        res.writeHead(404);
-        res.end();
-        return;
-      }
       fs.readFile(logFile, (err, data) => {
         if (err) {
           logger.error(`Error reading log file: ${err.message}`);

--- a/test.js
+++ b/test.js
@@ -3,9 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-const logFile = path.join(__dirname, 'test.log');
+const logFile = path.join(__dirname, 'server.log');
 try { fs.unlinkSync(logFile); } catch (e) {}
-process.env.LOG_FILE = logFile;
 
 const { startServer } = require('./server');
 


### PR DESCRIPTION
## Summary
- default to a local `server.log` file and pass it to the logger
- serve that log file from `/logs` so downloads work without extra env vars
- update test to validate log downloads without LOG_FILE

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68badabf0d5883218ffb41d2b4c97567