### PR TITLE
Fix download logs endpoint when no file present

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -6,6 +6,7 @@ function createLogger(options = {}) {
   const levelName = (options.level || process.env.LOG_LEVEL || 'info').toLowerCase();
   const levelIndex = levels.indexOf(levelName);
   const logFile = options.logFile || process.env.LOG_FILE;
+  const memoryLogs = [];
 
   function log(lvl, ...args) {
     if (levels.indexOf(lvl) < levelIndex) return;
@@ -13,6 +14,7 @@ function createLogger(options = {}) {
     const message = `[${timestamp}] ${lvl.toUpperCase()}: ${args.join(' ')}`;
     const consoleMethod = lvl === 'debug' ? 'log' : lvl;
     console[consoleMethod](message);
+    memoryLogs.push(message);
     if (logFile) {
       fs.appendFile(logFile, message + '\n', err => {
         if (err) console.error(`[LOGGER ERROR] ${err.message}`);
@@ -24,7 +26,8 @@ function createLogger(options = {}) {
     debug: (...a) => log('debug', ...a),
     info: (...a) => log('info', ...a),
     warn: (...a) => log('warn', ...a),
-    error: (...a) => log('error', ...a)
+    error: (...a) => log('error', ...a),
+    getLogs: () => memoryLogs.join('\n') + (memoryLogs.length ? '\n' : '')
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node test.js"
+    "test": "node test.js && node test-memory.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -46,24 +46,28 @@ function startServer(port = process.env.PORT || 8080) {
       });
     } else if (req.method === 'GET' && req.url === '/logs') {
       const logFile = process.env.LOG_FILE;
-      if (!logFile) {
-        res.writeHead(404);
-        res.end();
-        return;
-      }
-      fs.readFile(logFile, (err, data) => {
-        if (err) {
-          logger.error(`Error reading log file: ${err.message}`);
-          res.writeHead(500);
-          res.end('Server error');
-          return;
-        }
+      if (logFile) {
+        fs.readFile(logFile, (err, data) => {
+          if (err) {
+            logger.error(`Error reading log file: ${err.message}`);
+            res.writeHead(500);
+            res.end('Server error');
+            return;
+          }
+          res.writeHead(200, {
+            'Content-Type': 'text/plain',
+            'Content-Disposition': `attachment; filename="${path.basename(logFile)}"`
+          });
+          res.end(data);
+        });
+      } else {
+        const data = logger.getLogs();
         res.writeHead(200, {
           'Content-Type': 'text/plain',
-          'Content-Disposition': `attachment; filename="${path.basename(logFile)}"`
+          'Content-Disposition': 'attachment; filename="logs.txt"'
         });
         res.end(data);
-      });
+      }
     } else if (req.method === 'GET' && (req.url === '/' || req.url === '/index.html')) {
       fs.readFile(path.join(__dirname, 'index.html'), (err, data) => {
         if (err) {

--- a/test-memory.js
+++ b/test-memory.js
@@ -1,0 +1,58 @@
+const http = require('http');
+const assert = require('assert');
+
+const { startServer } = require('./server');
+
+const port = 8082;
+const server = startServer(port);
+let resRef;
+
+const req = http.request({ hostname: 'localhost', port, path: '/events', method: 'GET', headers: { Accept: 'text/event-stream' }
+ }, res => {
+  resRef = res;
+  res.setEncoding('utf8');
+  let buffer = '';
+  res.on('data', chunk => {
+    buffer += chunk;
+    const parts = buffer.split('\n\n');
+    if (parts.length > 1) {
+      for (const part of parts.slice(0, -1)) {
+        const line = part.trim();
+        if (line.startsWith('data:')) {
+          const msg = line.slice(5).trim();
+          console.log('Received:', msg);
+          fetchLogs();
+        }
+      }
+      buffer = parts[parts.length - 1];
+    }
+  });
+});
+req.end();
+
+setTimeout(() => {
+  const post = http.request({ hostname: 'localhost', port, path: '/message', method: 'POST' });
+  post.write('hello');
+  post.end();
+}, 100);
+
+function fetchLogs() {
+  setTimeout(() => {
+    http.get({ hostname: 'localhost', port, path: '/logs' }, res => {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', chunk => (body += chunk));
+      res.on('end', () => {
+        assert(body.includes('Broadcasting message'));
+        cleanup();
+      });
+    });
+  }, 50);
+}
+
+function cleanup() {
+  if (resRef) resRef.destroy();
+  server.close(() => {
+    process.exit(0);
+  });
+}


### PR DESCRIPTION
## Summary
- store log messages in memory when no log file is configured
- serve in-memory logs from `/logs` if `LOG_FILE` is undefined
- add regression tests for in-memory logging and update npm test script

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68badabf0d5883218ffb41d2b4c97567