### PR TITLE
Fix download logs endpoint when no file present

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <div id="inputRow">
     <input id="text" autocomplete="off" placeholder="Type a message" />
     <button id="send">Send</button>
-    <a id="downloadLogs" href="/logs">Download Logs</a>
+      <a id="downloadLogs" href="/logs" download>Download Logs</a>
   </div>
   <script>
     const statusEl = document.getElementById('status');

--- a/logger.js
+++ b/logger.js
@@ -6,6 +6,7 @@ function createLogger(options = {}) {
   const levelName = (options.level || process.env.LOG_LEVEL || 'info').toLowerCase();
   const levelIndex = levels.indexOf(levelName);
   const logFile = options.logFile || process.env.LOG_FILE;
+  const memoryLogs = [];
 
   function log(lvl, ...args) {
     if (levels.indexOf(lvl) < levelIndex) return;
@@ -13,6 +14,7 @@ function createLogger(options = {}) {
     const message = `[${timestamp}] ${lvl.toUpperCase()}: ${args.join(' ')}`;
     const consoleMethod = lvl === 'debug' ? 'log' : lvl;
     console[consoleMethod](message);
+    memoryLogs.push(message);
     if (logFile) {
       fs.appendFile(logFile, message + '\n', err => {
         if (err) console.error(`[LOGGER ERROR] ${err.message}`);
@@ -24,7 +26,8 @@ function createLogger(options = {}) {
     debug: (...a) => log('debug', ...a),
     info: (...a) => log('info', ...a),
     warn: (...a) => log('warn', ...a),
-    error: (...a) => log('error', ...a)
+    error: (...a) => log('error', ...a),
+    getLogs: () => memoryLogs.join('\n') + (memoryLogs.length ? '\n' : '')
   };
 }
 

--- a/logger.js
+++ b/logger.js
@@ -1,3 +1,4 @@
+"use strict";
 const fs = require('fs');
 
 const levels = ['debug', 'info', 'warn', 'error'];

--- a/logger.js
+++ b/logger.js
@@ -7,6 +7,10 @@ function createLogger(options = {}) {
   const levelIndex = levels.indexOf(levelName);
   const logFile = options.logFile || process.env.LOG_FILE;
   const memoryLogs = [];
+  const maxEntries = Number.parseInt(
+    options.maxEntries || process.env.LOG_MEMORY_SIZE || 1000,
+    10
+  );
 
   function log(lvl, ...args) {
     if (levels.indexOf(lvl) < levelIndex) return;
@@ -15,6 +19,9 @@ function createLogger(options = {}) {
     const consoleMethod = lvl === 'debug' ? 'log' : lvl;
     console[consoleMethod](message);
     memoryLogs.push(message);
+    if (memoryLogs.length > maxEntries) {
+      memoryLogs.shift();
+    }
     if (logFile) {
       fs.appendFile(logFile, message + '\n', err => {
         if (err) console.error(`[LOGGER ERROR] ${err.message}`);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node test.js && node test-memory.js"
+    "test": "node test.js && node test-memory.js && node test-memory-limit.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node test.js"
+    "test": "node test.js && node test-memory.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "whisper-chat",
   "version": "1.0.0",
   "private": true,
-  "description": "Simplistic server-sent events text chat",
+  "description": "Simplistic server-sent events text chat with in-memory logging",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",

--- a/server.js
+++ b/server.js
@@ -51,9 +51,18 @@ function startServer(port = process.env.PORT || 8080) {
       if (logFile) {
         fs.readFile(logFile, (err, data) => {
           if (err) {
-            logger.error(`Error reading log file: ${err.message}`);
-            res.writeHead(500);
-            res.end('Server error');
+            if (err.code === 'ENOENT') {
+              const memData = logger.getLogs();
+              res.writeHead(200, {
+                'Content-Type': 'text/plain',
+                'Content-Disposition': 'attachment; filename="logs.txt"'
+              });
+              res.end(memData);
+            } else {
+              logger.error(`Error reading log file: ${err.message}`);
+              res.writeHead(500);
+              res.end('Server error');
+            }
             return;
           }
           res.writeHead(200, {

--- a/server.js
+++ b/server.js
@@ -46,12 +46,20 @@ function startServer(port = process.env.PORT || 8080) {
         res.writeHead(204, { 'Access-Control-Allow-Origin': '*' });
         res.end();
       });
+    } else if (req.method === 'OPTIONS' && urlPath === '/logs') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+        'Access-Control-Allow-Headers': '*'
+      });
+      res.end();
     } else if ((req.method === 'GET' || req.method === 'HEAD') && urlPath === '/logs') {
       // Serve stored logs, falling back to in-memory entries when no log file exists
       const send = data => {
         res.writeHead(200, {
           'Content-Type': 'text/plain',
-          'Content-Disposition': 'attachment; filename="logs.txt"'
+          'Content-Disposition': 'attachment; filename="logs.txt"',
+          'Access-Control-Allow-Origin': '*'
         });
         if (req.method === 'HEAD') {
           res.end();
@@ -75,7 +83,8 @@ function startServer(port = process.env.PORT || 8080) {
           }
           res.writeHead(200, {
             'Content-Type': 'text/plain',
-            'Content-Disposition': `attachment; filename="${path.basename(logFile)}"`
+            'Content-Disposition': `attachment; filename="${path.basename(logFile)}"`,
+            'Access-Control-Allow-Origin': '*'
           });
           if (req.method === 'HEAD') {
             res.end();

--- a/server.js
+++ b/server.js
@@ -109,3 +109,4 @@ if (require.main === module) {
 }
 
 module.exports = { startServer };
+

--- a/server.js
+++ b/server.js
@@ -47,6 +47,7 @@ function startServer(port = process.env.PORT || 8080) {
         res.end();
       });
     } else if (req.method === 'GET' && urlPath === '/logs') {
+      // Serve stored logs, falling back to in-memory entries when no log file exists
       const logFile = process.env.LOG_FILE;
       if (logFile) {
         fs.readFile(logFile, (err, data) => {

--- a/test-memory-limit.js
+++ b/test-memory-limit.js
@@ -1,0 +1,44 @@
+const http = require('http');
+const assert = require('assert');
+
+const { startServer } = require('./server');
+
+process.env.LOG_FILE = '';
+process.env.LOG_MEMORY_SIZE = '2';
+
+const port = 8083;
+const server = startServer(port);
+
+function post(msg, cb) {
+  const req = http.request(
+    { hostname: 'localhost', port, path: '/message', method: 'POST' },
+    res => {
+      res.resume();
+      res.on('end', cb);
+    }
+  );
+  req.end(msg);
+}
+
+setTimeout(() => {
+  post('one', () => {
+    post('two', () => {
+      post('three', () => {
+        http.get({ hostname: 'localhost', port, path: '/logs' }, res => {
+          assert.strictEqual(res.statusCode, 200);
+          let body = '';
+          res.setEncoding('utf8');
+          res.on('data', chunk => (body += chunk));
+          res.on('end', () => {
+            assert(!body.includes('one'));
+            assert(body.includes('two'));
+            assert(body.includes('three'));
+            assert(!body.includes('Server running'));
+            server.close(() => process.exit(0));
+          });
+        });
+      });
+    });
+  });
+}, 50);
+

--- a/test-memory.js
+++ b/test-memory.js
@@ -51,10 +51,12 @@ function fetchLogs() {
     http
       .request({ hostname: 'localhost', port, path: '/logs?x=1', method: 'HEAD' }, resHead => {
         assert.strictEqual(resHead.statusCode, 200);
+        assert.strictEqual(resHead.headers['access-control-allow-origin'], '*');
         resHead.resume();
         resHead.on('end', () => {
           http.get({ hostname: 'localhost', port, path: '/logs?x=1' }, res => {
             assert.strictEqual(res.statusCode, 200);
+            assert.strictEqual(res.headers['access-control-allow-origin'], '*');
             let body = '';
             res.setEncoding('utf8');
             res.on('data', chunk => (body += chunk));

--- a/test-memory.js
+++ b/test-memory.js
@@ -3,31 +3,41 @@ const assert = require('assert');
 
 const { startServer } = require('./server');
 
+process.env.LOG_FILE = '/tmp/non-existent.log';
+
 const port = 8082;
 const server = startServer(port);
 let resRef;
 
-const req = http.request({ hostname: 'localhost', port, path: '/events', method: 'GET', headers: { Accept: 'text/event-stream' }
- }, res => {
-  resRef = res;
-  res.setEncoding('utf8');
-  let buffer = '';
-  res.on('data', chunk => {
-    buffer += chunk;
-    const parts = buffer.split('\n\n');
-    if (parts.length > 1) {
-      for (const part of parts.slice(0, -1)) {
-        const line = part.trim();
-        if (line.startsWith('data:')) {
-          const msg = line.slice(5).trim();
-          console.log('Received:', msg);
-          fetchLogs();
+const req = http.request(
+  {
+    hostname: 'localhost',
+    port,
+    path: '/events',
+    method: 'GET',
+    headers: { Accept: 'text/event-stream' }
+  },
+  res => {
+    resRef = res;
+    res.setEncoding('utf8');
+    let buffer = '';
+    res.on('data', chunk => {
+      buffer += chunk;
+      const parts = buffer.split('\n\n');
+      if (parts.length > 1) {
+        for (const part of parts.slice(0, -1)) {
+          const line = part.trim();
+          if (line.startsWith('data:')) {
+            const msg = line.slice(5).trim();
+            console.log('Received:', msg);
+            fetchLogs();
+          }
         }
+        buffer = parts[parts.length - 1];
       }
-      buffer = parts[parts.length - 1];
-    }
-  });
-});
+    });
+  }
+);
 req.end();
 
 setTimeout(() => {

--- a/test-memory.js
+++ b/test-memory.js
@@ -66,3 +66,4 @@ function cleanup() {
     process.exit(0);
   });
 }
+

--- a/test-memory.js
+++ b/test-memory.js
@@ -48,15 +48,24 @@ setTimeout(() => {
 
 function fetchLogs() {
   setTimeout(() => {
-    http.get({ hostname: 'localhost', port, path: '/logs?x=1' }, res => {
-      let body = '';
-      res.setEncoding('utf8');
-      res.on('data', chunk => (body += chunk));
-      res.on('end', () => {
-        assert(body.includes('Broadcasting message'));
-        cleanup();
-      });
-    });
+    http
+      .request({ hostname: 'localhost', port, path: '/logs?x=1', method: 'HEAD' }, resHead => {
+        assert.strictEqual(resHead.statusCode, 200);
+        resHead.resume();
+        resHead.on('end', () => {
+          http.get({ hostname: 'localhost', port, path: '/logs?x=1' }, res => {
+            assert.strictEqual(res.statusCode, 200);
+            let body = '';
+            res.setEncoding('utf8');
+            res.on('data', chunk => (body += chunk));
+            res.on('end', () => {
+              assert(body.includes('Broadcasting message'));
+              cleanup();
+            });
+          });
+        });
+      })
+      .end();
   }, 50);
 }
 

--- a/test-memory.js
+++ b/test-memory.js
@@ -1,19 +1,14 @@
 const http = require('http');
-const fs = require('fs');
-const path = require('path');
 const assert = require('assert');
-
-const logFile = path.join(__dirname, 'test.log');
-try { fs.unlinkSync(logFile); } catch (e) {}
-process.env.LOG_FILE = logFile;
 
 const { startServer } = require('./server');
 
-const port = 8081;
+const port = 8082;
 const server = startServer(port);
 let resRef;
 
-const req = http.request({ hostname: 'localhost', port, path: '/events', method: 'GET', headers: { Accept: 'text/event-stream' } }, res => {
+const req = http.request({ hostname: 'localhost', port, path: '/events', method: 'GET', headers: { Accept: 'text/event-stream' }
+ }, res => {
   resRef = res;
   res.setEncoding('utf8');
   let buffer = '';
@@ -58,7 +53,6 @@ function fetchLogs() {
 function cleanup() {
   if (resRef) resRef.destroy();
   server.close(() => {
-    try { fs.unlinkSync(logFile); } catch (e) {}
     process.exit(0);
   });
 }

--- a/test.js
+++ b/test.js
@@ -43,15 +43,24 @@ setTimeout(() => {
 
 function fetchLogs() {
   setTimeout(() => {
-    http.get({ hostname: 'localhost', port, path: '/logs?x=1' }, res => {
-      let body = '';
-      res.setEncoding('utf8');
-      res.on('data', chunk => (body += chunk));
-      res.on('end', () => {
-        assert(body.includes('Broadcasting message'));
-        cleanup();
-      });
-    });
+    http
+      .request({ hostname: 'localhost', port, path: '/logs?x=1', method: 'HEAD' }, resHead => {
+        assert.strictEqual(resHead.statusCode, 200);
+        resHead.resume();
+        resHead.on('end', () => {
+          http.get({ hostname: 'localhost', port, path: '/logs?x=1' }, res => {
+            assert.strictEqual(res.statusCode, 200);
+            let body = '';
+            res.setEncoding('utf8');
+            res.on('data', chunk => (body += chunk));
+            res.on('end', () => {
+              assert(body.includes('Broadcasting message'));
+              cleanup();
+            });
+          });
+        });
+      })
+      .end();
   }, 50);
 }
 


### PR DESCRIPTION
## Summary
- parse request URLs to handle cache-busting query strings for all routes
- ensure `/logs` downloads data even when queries are present
- exercise query string support in log download tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68badabf0d5883218ffb41d2b4c97567