### PR TITLE
Limit in-memory log entries

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -6,6 +6,7 @@ function createLogger(options = {}) {
   const levelName = (options.level || process.env.LOG_LEVEL || 'info').toLowerCase();
   const levelIndex = levels.indexOf(levelName);
   const logFile = options.logFile || process.env.LOG_FILE;
+  const maxEntries = options.maxEntries || parseInt(process.env.LOG_MEMORY_SIZE, 10) || 1000;
   const memoryLogs = [];
 
   function log(lvl, ...args) {
@@ -15,6 +16,7 @@ function createLogger(options = {}) {
     const consoleMethod = lvl === 'debug' ? 'log' : lvl;
     console[consoleMethod](message);
     memoryLogs.push(message);
+    if (memoryLogs.length > maxEntries) memoryLogs.shift();
     if (logFile) {
       fs.appendFile(logFile, message + '\n', err => {
         if (err) console.error(`[LOGGER ERROR] ${err.message}`);


### PR DESCRIPTION
## Summary
- cap logger's in-memory buffer by configurable size to prevent unbounded growth

## Testing
- `node test.js`
- `node test-memory.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbd2131fb08321a396d52d0fb93a69